### PR TITLE
Target Ruby 2.6, updated array/hash indent cop names

### DIFF
--- a/rubocop/rubocop_trailhead.yml
+++ b/rubocop/rubocop_trailhead.yml
@@ -16,7 +16,7 @@ AllCops:
     - 'db/migrate/*'
     - 'vendor/*'
 
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Metrics/LineLength:
   Max: 120
@@ -90,10 +90,10 @@ Style/RegexpLiteral:
 Style/Documentation:
   Enabled: false
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Style/ClassAndModuleChildren:


### PR DESCRIPTION
The Dev Happiness team brought in these changes for compatibility with Ruby 2.6 and Rubocop 0.68.1. I'm sharing them here in case they're of use.

**I recommend against pulling these changes in until all consumers are ready to upgrade both Ruby and Rubocop.**

* Set `TargetRubyVersion` to `2.6` (from `2.4`)
* Rename `Layout/IndentHash` and `Layout/IndentArray` to their new names, `Layout/IndentFirstHashElement` and `Layout/IndentFirstArrayElement`