### PR TITLE
Fix exclude file format in RuboCop config

### DIFF
--- a/rubocop/rubocop_trailhead.yml
+++ b/rubocop/rubocop_trailhead.yml
@@ -13,8 +13,8 @@ Rails/OutputSafety:
 AllCops:
   Exclude:
     - 'db/schema.rb'
-    - 'db/migrate/*'
-    - 'vendor/*'
+    - 'db/migrate/**/*'
+    - 'vendor/**/*'
 
   TargetRubyVersion: 2.4
 


### PR DESCRIPTION
Corrects a couple instances using a deprecated/incorrect format to exclude files ([docs](https://rubocop.readthedocs.io/en/latest/configuration/)).

A problem manifests when running RuboCop on a project like this:

```
bundle exec --path vendor/bundle
bundle exec rubocop
```

It incorrectly runs RuboCop on all the gems in `vendor/bundle`, and fails when it finds a `.rubocop.yml` that's incompatible with the RuboCop version being run.

This happens now when Semaphore tries to build this backpacker branch:
- PR: https://github.com/devforce/backpacker/pull/64
- [Failing Semaphore build](https://semaphoreci.com/trailhead/backpacker/branches/gemify/builds/13)

I've verified locally that this fix resolves the issue.