### PR TITLE
Fixed warnings when running rubocop locally

### DIFF
--- a/rubocop/rubocop_trailhead.yml
+++ b/rubocop/rubocop_trailhead.yml
@@ -7,9 +7,6 @@ require: rubocop-rspec
 Rails:
   Enabled: true
 
-Rails/OutputSafety:
-  Enabled: true
-
 AllCops:
   Exclude:
     - 'db/schema.rb'
@@ -142,13 +139,6 @@ Style/RescueModifier:
 Style/BlockComments:
   Description: 'Do not use block comments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-block-comments'
-  Enabled: false
-
-Rails/HasAndBelongsToMany:
-  Enabled: false
-
-# incompatible with Rails 4
-Rails/HttpPositionalArguments:
   Enabled: false
 
 Style/IfUnlessModifier:

--- a/rubocop/rubocop_trailhead.yml
+++ b/rubocop/rubocop_trailhead.yml
@@ -18,7 +18,7 @@ AllCops:
 
   TargetRubyVersion: 2.6
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/ClassLength:
@@ -44,7 +44,7 @@ Metrics/PerceivedComplexity:
 Metrics/AbcSize:
   Max: 23
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_first_parameter
   Enabled: true
 
@@ -60,26 +60,13 @@ Style/FrozenStringLiteralComment:
 Style/TernaryParentheses:
   Enabled: false
 
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
-
 Style/SymbolArray:
   EnforcedStyle: brackets
-
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyleForEmptyBraces: no_space
-  EnforcedStyle: space
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
 Style/BlockDelimiters:
-  Enabled: false
-
-Style/BracesAroundHashParameters:
   Enabled: false
 
 Style/RegexpLiteral:
@@ -90,10 +77,10 @@ Style/RegexpLiteral:
 Style/Documentation:
   Enabled: false
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Style/ClassAndModuleChildren:
@@ -158,9 +145,6 @@ Style/BlockComments:
   Enabled: false
 
 Rails/HasAndBelongsToMany:
-  Enabled: false
-
-Rails/FilePath:
   Enabled: false
 
 # incompatible with Rails 4


### PR DESCRIPTION
```
.rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml:72: `Layout/SpaceInsideHashLiteralBraces` is concealed by line 176
.rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml:63: `Style/TrailingCommaInArrayLiteral` is concealed by line 182
.rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml:66: `Style/TrailingCommaInHashLiteral` is concealed by line 186
.rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml: Metrics/LineLength has the wrong namespace - should be Layout
.rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml: Rails/FilePath has the wrong namespace - should be RSpec
Error: The `Layout/AlignParameters` cop has been renamed to `Layout/ParameterAlignment`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml, please update it)
The `Layout/IndentFirstArrayElement` cop has been renamed to `Layout/FirstArrayElementIndentation`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml, please update it)
The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml, please update it)
The `Style/BracesAroundHashParameters` cop has been removed.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-devforce-dotfiles-master-rubocop-rubocop-trailhead-yml, please update it)
```